### PR TITLE
fix: grid to battery calculation in absence of solar production

### DIFF
--- a/src/energy-flow-card-plus.ts
+++ b/src/energy-flow-card-plus.ts
@@ -786,7 +786,14 @@ export default class EnergyFlowCardPlus extends SubscribeMixin(LitElement) {
       }
       solar.state.toBattery = battery.state.toBattery! - (grid.state.toBattery || 0);
     } else if (!solar.has && battery.has) {
+      // In the absence of solar production, the battery is the only energy producer
+      // besides the grid, so whatever was given to the grid must come from
+      // the battery
       battery.state.toGrid = grid.state.toGrid ?? 0;
+
+      // In the absence of solar production, what was consumed by the battery
+      // must come from the grid, since there are no other energy producers.
+      grid.state.toBattery = (battery.state.toBattery ?? 0);
     }
 
     // Update State Values of Solar to Grid
@@ -855,7 +862,7 @@ export default class EnergyFlowCardPlus extends SubscribeMixin(LitElement) {
     const totalIndividualConsumption = coerceNumber(individual1.state, 0) + coerceNumber(individual2.state, 0);
 
     // Calculate Sum of All Sources to get Total Home Consumption
-    const totalHomeConsumption = Math.max(grid.state.fromGrid + (solar.state.toHome ?? 0) + (battery.state.toHome ?? 0), 0);
+    const totalHomeConsumption = Math.max(grid.state.fromGrid - (grid.state.toBattery ?? 0) + (solar.state.toHome ?? 0) + (battery.state.toHome ?? 0), 0);
 
     // Calculate Circumference of Semi-Circles
     let homeBatteryCircumference = 0;


### PR DESCRIPTION
There is an issue with the reporting of "grid to battery" in my off-grid setup. I use a generator as the "grid" source, which is not always online, but when online it is used to charge the battery. The battery is then discharged to the house later.

In my setup, there are only two energy producers:
1) the generator (grid import energy)
2) the battery (discharge energy)

The home is only a consumer, it does not produce energy. Therefore whatever is exported to the grid must come from the only other producer available, the battery. And vice-versa, whatever is charged into the battery must come from the grid export.

I've added code to calculate `grid.state.toBattery` in the case where solar isn't configured.

I've additionally changed `totalHomeConsumption` to take the total grid export (`grid.state.fromGrid`) and deduct the energy that is sent from the grid to the battery (`grid.state.toBattery`), since that energy isn't going to the home.

Before:
![image](https://github.com/flixlix/energy-flow-card-plus/assets/2053039/c1e5329b-64f2-422a-8f86-3726eb78a5ee)

After: 
![image](https://github.com/flixlix/energy-flow-card-plus/assets/2053039/a641ec72-7e76-4869-92b9-6db3896bd591)

This _may_ fix some bug reports such as https://github.com/flixlix/energy-flow-card-plus/issues/67 however I'm not sure if it is a complete fix since the original author had a different setup than mine.

@flixlix for your review