### PR TITLE
docs: Remove obsolete UI-Editor note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
    
 ## Using the card
 
-> ⚠️ This card also has a UI-Editor. This Editor is currently incompatible with Card Mod. I created a PR to fix this issue, but it hasn't been merged yet. Here is the [PR #277](https://github.com/thomasloven/lovelace-card-mod/pull/277). Since it hasn't been merged yet, I also released a fork with the changes from the PR. Installing this Version of Card Mod you can use this card in conjunction with Card Mod. [Here is my fork](https://github.com/flixlix/lovelace-card-mod)
-
 > ⚠️ This card offers a **LOT** of configuration options. Don't worry, if you want your card's appearance to match the oficial Energy Flow Card, you will only need to setup the entities. The rest of the options only enable further customization. If this is your goal, please go to [Minimal Configuration](#minimal-configuration)
 
 


### PR DESCRIPTION
Remove outdated information about UI-Editor incompatibility

The needed PR has already been incorporated in lovelace-card-mod Cf. commit https://github.com/thomasloven/lovelace-card-mod/commit/e7405bf3b2b641bc290d304c18f72439436e5f6a

Issue flixlix/flixlix-cards#33