### PR TITLE
fix: adapt to HA's new energy collection key system

### DIFF
--- a/src/energy-flow-card-plus-config.ts
+++ b/src/energy-flow-card-plus-config.ts
@@ -16,6 +16,7 @@ interface mainConfigOptions {
   min_expected_energy?: number;
   display_zero_lines?: boolean;
   energy_date_selection?: boolean;
+  collection_key?: string;
   use_new_flow_rate_model?: boolean;
 }
 

--- a/src/energy-flow-card-plus.ts
+++ b/src/energy-flow-card-plus.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { LitElement, html, TemplateResult, svg, PropertyValues } from 'lit';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { customElement, property, query, state } from 'lit/decorators';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import type { Config, EntityType, baseEntity } from './types';
 import localize from './localize/localize';
 import { coerceNumber, coerceStringArray, isNumberValue, renderError } from './utils';
@@ -59,11 +59,11 @@ export default class EnergyFlowCardPlus extends SubscribeMixin(LitElement) {
       resolve: (value: EnergyCollection | PromiseLike<EnergyCollection>) => void,
       reject: (reason?: any) => void,
     ) => {
-      const energyCollection = getEnergyDataCollection(this.hass);
+      const energyCollection = getEnergyDataCollection(this.hass, this._config?.collection_key);
       if (energyCollection) {
         resolve(energyCollection);
       } else if (Date.now() - start > energyDataTimeout) {
-        console.debug(getEnergyDataCollection(this.hass));
+        console.debug(getEnergyDataCollection(this.hass, this._config?.collection_key));
         reject(new Error('No energy data received. Make sure to add a `type: energy-date-selection` card to this screen.'));
       } else {
         setTimeout(() => getEnergyDataCollectionPoll(resolve, reject), 100);
@@ -73,7 +73,7 @@ export default class EnergyFlowCardPlus extends SubscribeMixin(LitElement) {
     setTimeout(() => {
       if (!this.error && !Object.keys(this.states).length) {
         this.error = new Error('Something went wrong. No energy data received.');
-        console.debug(getEnergyDataCollection(this.hass));
+        console.debug(getEnergyDataCollection(this.hass, this._config?.collection_key));
       }
     }, energyDataTimeout * 2);
     energyPromise.catch(err => {
@@ -261,7 +261,7 @@ export default class EnergyFlowCardPlus extends SubscribeMixin(LitElement) {
     if (value === null) return '0';
     if (Number.isNaN(+value)) return value.toString();
     const valueInNumber = Number(value);
-    const isMwh = unit === undefined && valueInNumber * 1000 >= this._config!.kwh_mwh_threshold!;
+    const isMwh = unit === undefined && valueInNumber / 1000 >= this._config!.kwh_mwh_threshold!;
     const isKWh = unit === undefined && valueInNumber >= this._config!.wh_kwh_threshold!;
     const v = formatNumber(
       isMwh

--- a/src/energy/index.ts
+++ b/src/energy/index.ts
@@ -102,11 +102,24 @@ export interface EnergyCollection extends Collection<EnergyData> {
   _active: number;
 }
 
-export const getEnergyDataCollection = (hass: HomeAssistant, key = '_energy'): EnergyCollection | null => {
-  if ((hass.connection as any)[key]) {
-    return (hass.connection as any)[key];
+export const getEnergyDataCollection = (hass: HomeAssistant, collectionKey?: string): EnergyCollection | null => {
+  const conn = hass.connection as any;
+  const panelUrl = (hass as any).panelUrl;
+
+  let key = '_energy';
+  if (collectionKey) {
+    key = `_${collectionKey}`;
+  } else if (panelUrl) {
+    key = `_energy_${panelUrl}`;
   }
-  // HA has not initialized the collection yet and we don't want to interfere with that
+
+  if (conn[key]) {
+    return conn[key];
+  }
+  // Fallback to the legacy key for older HA versions
+  if (key !== '_energy' && conn._energy) {
+    return conn._energy;
+  }
   return null;
 };
 

--- a/src/energy/subscribe-mixin.ts
+++ b/src/energy/subscribe-mixin.ts
@@ -6,7 +6,7 @@
 import { HomeAssistant } from "custom-card-helpers";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { PropertyValues, ReactiveElement } from "lit";
-import { property } from "lit/decorators";
+import { property } from "lit/decorators.js";
 
 export interface HassSubscribeElement {
   hassSubscribe(): UnsubscribeFunc[];


### PR DESCRIPTION
HA changed energy data collections from a static `_energy` key to `_energy_${panelUrl}`. Update getEnergyDataCollection to derive the key from hass.panelUrl, with fallback for older HA versions and support for explicit collection_key config. Also fix MWh threshold check that used multiplication instead of division, causing all values to display as MWh.